### PR TITLE
Allow immediate flushing of mcux lpuart

### DIFF
--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -619,7 +619,7 @@ static int mcux_lpuart_rx_disable(const struct device *dev)
 
 	/* No active RX buffer, cannot disable */
 	if (!data->async.rx_dma_params.buf) {
-		LOG_ERR("No buffers to release from RX DMA!");
+		LOG_WRN("No buffers to release from RX DMA!");
 	} else {
 		mcux_lpuart_async_rx_flush(dev);
 		async_evt_rx_buf_release(dev);

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -500,7 +500,7 @@ static void async_evt_rx_rdy(const struct device *dev)
 	};
 
 	LOG_DBG("RX Ready: (len: %zu off: %zu buf: %p)", event.data.rx.len,
-		event.data.rx.offset, event.data.rx.buf);
+		event.data.rx.offset, (void *)event.data.rx.buf);
 
 	/* Only send event for new data */
 	if (event.data.rx.len > 0) {

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -431,7 +431,7 @@ static void mcux_lpuart_irq_callback_set(const struct device *dev,
 #if LPUART_ASYNC_ENABLE
 static inline void async_timer_start(struct k_work_delayable *work, size_t timeout_us)
 {
-	if ((timeout_us != SYS_FOREVER_US) && (timeout_us != 0)) {
+	if (timeout_us != SYS_FOREVER_US) {
 		LOG_DBG("async timer started for %d us", timeout_us);
 		k_work_reschedule(work, K_USEC(timeout_us));
 	}
@@ -853,7 +853,10 @@ static int mcux_lpuart_tx(const struct device *dev, const uint8_t *buf, size_t l
 			LOG_ERR("Failed to start DMA(Tx) Ch %d",
 				config->tx_dma_config.dma_channel);
 		}
-		async_timer_start(&data->async.tx_dma_params.timeout_work, timeout_us);
+
+		if (timeout_us > 0) {
+			async_timer_start(&data->async.tx_dma_params.timeout_work, timeout_us);
+		}
 	} else {
 		LOG_ERR("Error configuring UART DMA: %x", ret);
 	}
@@ -1058,8 +1061,13 @@ static inline void mcux_lpuart_async_isr(const struct device *dev,
 	}
 
 	if (status & kLPUART_IdleLineFlag) {
-		async_timer_start(&data->async.rx_dma_params.timeout_work,
-				  data->async.rx_dma_params.timeout_us);
+		if (data->async.rx_dma_params.timeout_us == 0) {
+			mcux_lpuart_async_rx_flush(dev);
+		}
+		else {
+			async_timer_start(&data->async.rx_dma_params.timeout_work,
+				data->async.rx_dma_params.timeout_us);
+		}
 		LPUART_ClearStatusFlags(config->base, kLPUART_IdleLineFlag);
 	}
 }


### PR DESCRIPTION
This PR aims to make the behavior of mcux_lpuart similar to other implementations when an operation timeout is given as zero. In order for the RX_RDY event to be properly sent on a partial DMA transmissions (i.e. one that does not a fill an entire DMA buffer), mcux_lpuart_async_rx_flush must be manually called.

Also make the handling of zero timeout more explicit for TX. Previously, async_timer_start would avoid calling k_work_reschedule if the timeout was zero. This change makes the behavior more explicit by skipping the call to async_timer_start altogether.