### PR TITLE
net: dns: Rename struct dns_server to avoid C++ name clash

### DIFF
--- a/include/zephyr/net/dns_resolve.h
+++ b/include/zephyr/net/dns_resolve.h
@@ -438,7 +438,7 @@ enum dns_resolve_context_state {
  */
 struct dns_resolve_context {
 	/** List of configured DNS servers */
-	struct dns_server {
+	struct dns_server_info {
 		/** DNS server information */
 		struct net_sockaddr dns_server;
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -375,7 +375,7 @@ unlock:
 
 static int register_dispatcher(struct dns_resolve_context *ctx,
 			       const struct net_socket_service_desc *svc,
-			       struct dns_server *server,
+			       struct dns_server_info *server,
 			       struct net_sockaddr *local,
 			       const struct net_in6_addr *addr6,
 			       const struct net_in_addr *addr4)


### PR DESCRIPTION
dns: fix C++ compilation of dns_resolve.h

The dns_server struct has aa member with the same name as the struct
tag, which is illegal C++. Fix the issue by renamin the struct to
dns_server_info, as done in the upstream's commit 5d50983.

Upstream-Status: Backport[5d50983]
Signed-off-by: Guilherme Costa <guilhermecosta@stratioautomotive.com>